### PR TITLE
OPS-2484: Fix bug where it returns all terms and conditions

### DIFF
--- a/lib/connectors/database.js
+++ b/lib/connectors/database.js
@@ -1,8 +1,6 @@
 var mysql = require('mysql');
 var VError = require('verror');
 var pool = null;
-var util = require('util');
-
 
 var database = function(opts){
   if(!opts) {
@@ -19,40 +17,29 @@ database.prototype._queryWithValues = function(opts, callback){
   return pool.query(opts.sql, opts.values, callback);
 };
 
-database.prototype.checkForParagraphs = function(doc, date, callback) {
-  if(!doc) return callback(new VError('doc parameter not passed to checkForParagraphs.'));
-  if(date && isNaN(Date.parse(date))) return callback(new VError('date parameter passed to _getVersion in an incorrect format.'));
-  if(!date) date = 'NOW()'; // If theres no date passed in, get latest document with NOW()
-  var docsWithSubdirectories = doc + '%';
-  console.log('Booking Date', date);
-  var query = 'SELECT type, content FROM ?? \
-    WHERE `type` LIKE ? AND `date` <= ? \
-    GROUP BY type;';
-  var options = {
-    sql: query,
-    values: [this.config.table, docsWithSubdirectories, date]
-  };
-  this._queryWithValues(options, function(err, rows){
-    console.log(err);
-    if(err) return callback(err);
-    if(!rows || !rows[0]) return callback(null, [{ type: doc }]);
-    if(rows && rows.type) rows.type = JSON.parse(rows.type);
-    console.log('DOC_CHECKING', util.inspect(doc));
-    console.log('DB ROWS', util.inspect(rows));
-    return callback(null, rows);
+database.prototype._removeMixedFormats = function(rows) {
+  if (rows.length === 1) return rows;
+  return rows.filter(function(row) {
+    return /\//.test(row.type);
   });
 };
 
 database.prototype.getDocument = function(doc, date, callback){
-  console.log('DOC to fetch', doc);
+  var self = this;
   if(!doc) return callback(new VError('doc parameter not passed to getDocument.'));
   if(date && isNaN(Date.parse(date))) return callback(new VError('date parameter passed to _getVersion in an incorrect format.'));
   if(!date) date = 'NOW()'; // If theres no date passed in, get latest document with NOW()
-
+  /*
+    This query search for the most recent of each set of terms before the date passed in
+    This is in order to allow it to support the structure of older terms and conditions
+  */
+  var tabelName = this.config.table;
   var query = 'SELECT type, MAX(date) AS date, \
-    (SELECT rules FROM ' + this.config.table + ' v2 WHERE v2.type = v.type AND v2.date = max(v.date)) AS rules, \
-    (SELECT content FROM ' + this.config.table + ' v2 WHERE v2.type = v.type AND v2.date = max(v.date)) AS content \
-    FROM ' + this.config.table + ' v \
+    (SELECT DISTINCT rules FROM ' + tabelName + ' \
+      v2 WHERE v2.type = v.type AND v2.date = max(v.date)) AS rules, \
+    (SELECT DISTINCT content FROM ' + tabelName + ' \
+      v2 WHERE v2.type = v.type AND v2.date = max(v.date)) AS content \
+    FROM ' + tabelName + ' v \
     WHERE type LIKE ? \
     AND date <= ? \
     GROUP BY type;'
@@ -64,23 +51,17 @@ database.prototype.getDocument = function(doc, date, callback){
   this._queryWithValues(options, function(err, rows){
     if(err) return callback(err);
     if(!rows || !rows[0]) return callback();
-    var results = [];
-    if (rows.length === 1) {
-      results.push(rows[0]);
-    } else {
-      rows.splice(0, 1);
-      results = rows;
-    }
-    console.log('RESULTS', rows);
-    var finalResults = results.map(function(result) {
-      if(!result.rules) result.rules = {};
+    rows = self._removeMixedFormats(rows);
+
+    var finalResults = rows.map(function(row) {
+      if(!row.rules) row.rules = {};
 
       try{
-        result.rules = JSON.parse(result.rules);
+        row.rules = JSON.parse(row.rules);
       } catch(e) {
-        result.rules = {};
+        row.rules = {};
       }
-      return result
+      return row
     });
     return callback(null, finalResults);
   });

--- a/lib/connectors/database.js
+++ b/lib/connectors/database.js
@@ -1,6 +1,8 @@
 var mysql = require('mysql');
 var VError = require('verror');
 var pool = null;
+var util = require('util');
+
 
 var database = function(opts){
   if(!opts) {
@@ -17,52 +19,70 @@ database.prototype._queryWithValues = function(opts, callback){
   return pool.query(opts.sql, opts.values, callback);
 };
 
-database.prototype.checkForParagraphs = function(doc, callback) {
+database.prototype.checkForParagraphs = function(doc, date, callback) {
   if(!doc) return callback(new VError('doc parameter not passed to checkForParagraphs.'));
-  var docsWithSubdirectories = '%' + doc + '%';
-
-  var query = 'SELECT type FROM ?? \
-    WHERE `type` LIKE ? ORDER BY type ASC;';
+  if(date && isNaN(Date.parse(date))) return callback(new VError('date parameter passed to _getVersion in an incorrect format.'));
+  if(!date) date = 'NOW()'; // If theres no date passed in, get latest document with NOW()
+  var docsWithSubdirectories = doc + '%';
+  console.log('Booking Date', date);
+  var query = 'SELECT type, content FROM ?? \
+    WHERE `type` LIKE ? AND `date` <= ? \
+    GROUP BY type;';
   var options = {
     sql: query,
-    values: [this.config.table, docsWithSubdirectories]
+    values: [this.config.table, docsWithSubdirectories, date]
   };
-
   this._queryWithValues(options, function(err, rows){
+    console.log(err);
     if(err) return callback(err);
-    if(!rows || !rows[0]) return callback();
+    if(!rows || !rows[0]) return callback(null, [{ type: doc }]);
     if(rows && rows.type) rows.type = JSON.parse(rows.type);
-
+    console.log('DOC_CHECKING', util.inspect(doc));
+    console.log('DB ROWS', util.inspect(rows));
     return callback(null, rows);
   });
 };
 
 database.prototype.getDocument = function(doc, date, callback){
+  console.log('DOC to fetch', doc);
   if(!doc) return callback(new VError('doc parameter not passed to getDocument.'));
   if(date && isNaN(Date.parse(date))) return callback(new VError('date parameter passed to _getVersion in an incorrect format.'));
   if(!date) date = 'NOW()'; // If theres no date passed in, get latest document with NOW()
 
-  var query = 'SELECT content, rules FROM ?? \
-    WHERE `type` = ? AND `date` <= ? ORDER BY date DESC LIMIT 1;'
+  var query = 'SELECT type, MAX(date) AS date, \
+    (SELECT rules FROM ' + this.config.table + ' v2 WHERE v2.type = v.type AND v2.date = max(v.date)) AS rules, \
+    (SELECT content FROM ' + this.config.table + ' v2 WHERE v2.type = v.type AND v2.date = max(v.date)) AS content \
+    FROM ' + this.config.table + ' v \
+    WHERE type LIKE ? \
+    AND date <= ? \
+    GROUP BY type;'
   var options = {
     sql: query,
-    values: [this.config.table, doc, date]
+    values: [doc + '%', date]
   };
 
-  this._queryWithValues(options, function(err, row){
+  this._queryWithValues(options, function(err, rows){
     if(err) return callback(err);
-    if(!row || !row[0]) return callback();
-
-    var result = row[0];
-    if(!result.rules) result.rules = {};
-
-    try{
-      result.rules = JSON.parse(result.rules);
-    } catch(e) {
-      result.rules = {};
+    if(!rows || !rows[0]) return callback();
+    var results = [];
+    if (rows.length === 1) {
+      results.push(rows[0]);
+    } else {
+      rows.splice(0, 1);
+      results = rows;
     }
+    console.log('RESULTS', rows);
+    var finalResults = results.map(function(result) {
+      if(!result.rules) result.rules = {};
 
-    return callback(null, result);
+      try{
+        result.rules = JSON.parse(result.rules);
+      } catch(e) {
+        result.rules = {};
+      }
+      return result
+    });
+    return callback(null, finalResults);
   });
 
 };

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -22,27 +22,16 @@ docWarrior.prototype.get = function(opts, callback){
 
   var date = opts.params && opts.params.date ? opts.params.date : null;
   var docs = [];
-  var docsWithSubdirectories = [];
-
-  self._processSubdirectories(opts.docs, function(err, alldirectories) {
-    var mergedDirectories = [].concat.apply([], alldirectories);
-    mergedDirectories.forEach(function(directory) {
-      docsWithSubdirectories.push(directory.type);
-    });
-
-    async.each(docsWithSubdirectories, function(docType, callback) {
-      self._processDocument(docType, date, opts.params, function(err, content){
-        if(err) return callback(err);
-        docs[docType] = content;
-        return callback();
-      });
-    }, function(err){
+  async.each(opts.docs, function(docType, callback) {
+    self._processDocument(docType, date, opts.params, function(err, content){
       if(err) return callback(err);
-      var finalContent = self._returnInOrder(docsWithSubdirectories, docs);
-
-      return callback(null, finalContent);
+      docs[docType] = content;
+      return callback();
     });
-
+  }, function(err){
+    if(err) return callback(err);
+    var finalContent = self._returnInOrder(opts.docs, docs);
+    return callback(null, finalContent);
   });
 };
 
@@ -50,14 +39,17 @@ docWarrior.prototype._processDocument = function(docType, date, params, callback
   var self = this;
   if(!docType) return callback(new VError('No docType passed to _processDocument'));
 
-  this._getDocument(docType, date, function(err, doc){
-    if(err || !doc) return callback(err, '');
-
-    if(!doc.rules || Object.keys(doc.rules).length === 0) {
-      return callback(null, doc.content);
-    }
-    if(self._runDocumentRules(doc.rules, params)) return callback(null, doc.content);
-    return callback(null, '');
+  this._getDocument(docType, date, function(err, docs){
+    if(err || !docs) return callback(err, '');
+    console.log('DOCx', docs);
+    var contentToReturn = docs.filter(function(doc) {
+      console.log('before rules', doc.type);
+      return (!doc.rules || Object.keys(doc.rules).length === 0) || (self._runDocumentRules(doc.rules, params));
+    }).map(function(doc) {
+        console.log('after rules', doc.type)
+        return doc.content;
+    }).join('\n');
+    return callback(null, contentToReturn);
   });
 };
 
@@ -107,24 +99,33 @@ docWarrior.prototype._returnInOrder = function(requested, docs){
   return finalContent;
 };
 
-docWarrior.prototype._processSubdirectories = function(parentDirectories, callback) {
-  var self = this;
-  if(!parentDirectories) return [];
-
-  var finalArray = [];
-
-  async.each(parentDirectories, function(directory, callback) {
-    self.connector.checkForParagraphs(directory, function(err, paragraphs) {
-      if(err) return callback(err);
-      finalArray.push(paragraphs);
-      return callback();
-    });
-  }, function(err) {
-    if(err) return callback(err);
-
-    return callback(null, finalArray);
-  });
-
+docWarrior.prototype._checkForSubdirectories = function(parentDirectory, date, callback) {
+  // this.connector.checkForParagraphs(parentDirectory, date, function(err, data) {
+  //   if (err) callback(err);
+  //   callback(null, data);
+  // });
+  callback(null, 'Tobenna');
 };
+
+// docWarrior.prototype._processSubdirectories = function(parentDirectories, callback) {
+//   console.log('PARENT Directories', parentDirectories);
+//   var self = this;
+//   if(!parentDirectories) return [];
+//
+//   var finalArray = [];
+//
+//   async.each(parentDirectories, function(directory, callback) {
+//     self.connector.checkForParagraphs(directory, function(err, paragraphs) {
+//       if(err) return callback(err);
+//       finalArray.push(paragraphs);
+//       return callback();
+//     });
+//   }, function(err) {
+//     if(err) return callback(err);
+//
+//     return callback(null, finalArray);
+//   });
+//
+// };
 
 module.exports = docWarrior;

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -41,12 +41,9 @@ docWarrior.prototype._processDocument = function(docType, date, params, callback
 
   this._getDocument(docType, date, function(err, docs){
     if(err || !docs) return callback(err, '');
-    console.log('DOCx', docs);
     var contentToReturn = docs.filter(function(doc) {
-      console.log('before rules', doc.type);
       return (!doc.rules || Object.keys(doc.rules).length === 0) || (self._runDocumentRules(doc.rules, params));
     }).map(function(doc) {
-        console.log('after rules', doc.type)
         return doc.content;
     }).join('\n');
     return callback(null, contentToReturn);
@@ -99,33 +96,5 @@ docWarrior.prototype._returnInOrder = function(requested, docs){
   return finalContent;
 };
 
-docWarrior.prototype._checkForSubdirectories = function(parentDirectory, date, callback) {
-  // this.connector.checkForParagraphs(parentDirectory, date, function(err, data) {
-  //   if (err) callback(err);
-  //   callback(null, data);
-  // });
-  callback(null, 'Tobenna');
-};
-
-// docWarrior.prototype._processSubdirectories = function(parentDirectories, callback) {
-//   console.log('PARENT Directories', parentDirectories);
-//   var self = this;
-//   if(!parentDirectories) return [];
-//
-//   var finalArray = [];
-//
-//   async.each(parentDirectories, function(directory, callback) {
-//     self.connector.checkForParagraphs(directory, function(err, paragraphs) {
-//       if(err) return callback(err);
-//       finalArray.push(paragraphs);
-//       return callback();
-//     });
-//   }, function(err) {
-//     if(err) return callback(err);
-//
-//     return callback(null, finalArray);
-//   });
-//
-// };
 
 module.exports = docWarrior;

--- a/lib/rules/notEqual.js
+++ b/lib/rules/notEqual.js
@@ -1,21 +1,14 @@
 var notEqual = function(matchArray, match){
-  if(!matchArray || !matchArray instanceof Array) return false;
-  if(!match || typeof match !== 'string') return false;
-
-  match = match.toUpperCase();
-
-  var arrayLength = matchArray.length;
+  if(!matchArray || !matchArray instanceof Array) return true;
+  if(!match || typeof match !== 'string') return true;
   
-  for (var i = 0; i < arrayLength; i++) {
-    var compare = matchArray[i];
-    if(!typeof compare == 'string') return false;
-    compare = compare.toUpperCase();
-    if(compare === match) {
-      return false;
-    }
-  }
-
-  return true;
+  var matches = matchArray.map(function(matchItem) {
+    matchItem + '';
+    return matchItem.toUpperCase();
+  }).filter(function(matchItem) {
+    return match.toUpperCase() === matchItem;
+  });
+  return matches.length === 0;
 };
 
 module.exports = notEqual;

--- a/tests/testDatabase.js
+++ b/tests/testDatabase.js
@@ -37,7 +37,7 @@ describe('Unit - database', function(){
     it('should callback if no rows are found', function(){
       sinon.stub(connector, '_queryWithValues').callsArgWith(1, null, []);
       connector.getDocument('somedoc', null, callback);
-      assert.equal(callback.firstCall.args[0], 'No documents matching your search');
+      assert.equal(callback.firstCall.args[0], null);
       assert.equal(callback.firstCall.args[1], null);
       connector._queryWithValues.restore();
     });

--- a/tests/testDatabase.js
+++ b/tests/testDatabase.js
@@ -37,57 +37,36 @@ describe('Unit - database', function(){
     it('should callback if no rows are found', function(){
       sinon.stub(connector, '_queryWithValues').callsArgWith(1, null, []);
       connector.getDocument('somedoc', null, callback);
-      assert.equal(callback.firstCall.args[0], null);
+      assert.equal(callback.firstCall.args[0], 'No documents matching your search');
       assert.equal(callback.firstCall.args[1], null);
       connector._queryWithValues.restore();
     });
 
-    it('should callback result if rows in database', function(){
-      sinon.stub(connector, '_queryWithValues').callsArgWith(1, null, ['data']);
+    it('should remove the old format rules when there are multiple results', function() {
+      var rowData = [
+        { type: 'data1' }, { type: 'data/2'}, { type: 'data/3'}
+      ];
+      var returnsWith = [
+          {
+             "rules": {},
+             "type": "data/2"
+           },
+           {
+              "rules": {},
+              "type": "data/3"
+            }
+      ]
+      sinon.stub(connector, '_queryWithValues').callsArgWith(1, null, rowData);
       connector.getDocument('somedoc', null, callback);
-      assert.equal(callback.firstCall.args[1], 'data');
+      assert.deepEqual(callback.firstCall.args[1], returnsWith);
       connector._queryWithValues.restore();
     });
 
-  });
-
-  describe('checkForParagraphs', function() {
-    var callback = null;
-
-    beforeEach(function(){
-      callback = sinon.spy();
-    });
-
-    afterEach(function(){
-      callback = null;
-    });
-
-    context('when no doc, or an empty string is passed', function() {
-      it('should return an error with null passed in', function(){
-        connector.checkForParagraphs(null, callback);
-        assert.deepEqual(callback.firstCall.args[0], new VError('doc parameter not passed to checkForParagraphs.'));
-      });
-    });
-
-    context('when a document string is passed', function() {
-      var doc;
-      var queryWithValues = null;
-
-      beforeEach(function() {
-        doc = 'terms_and_conditions';
-        queryWithValues = sinon.stub(connector, '_queryWithValues');
-      });
-
-      it('should call _queryWithValues with the correctly formatted options', function() {
-        var expectedOptions = {
-          sql: 'SELECT type FROM ??     WHERE `type` LIKE ? ORDER BY type ASC;',
-          values: ['versions', '%terms_and_conditions%']
-        }
-        connector.checkForParagraphs(doc, callback);
-        assert.ok(connector._queryWithValues.calledWith(expectedOptions));
-        queryWithValues = null;
-      });
+    it('should callback only one row if one row is found', function() {
+      sinon.stub(connector, '_queryWithValues').callsArgWith(1, null, ['data']);
+      connector.getDocument('somedoc', null, callback);
+      assert.deepEqual(callback.firstCall.args[1], ['data']);
+      connector._queryWithValues.restore();
     });
   });
-
 });

--- a/tests/testDocs.js
+++ b/tests/testDocs.js
@@ -49,30 +49,6 @@ describe('Unit - docs', function(){
       });
 
     });
-
-    context('With good input and subdirectories', function(){
-      var processDocStub = null;
-
-      beforeEach(function() {
-        sinon.stub(docs, '_processSubdirectories').yields(['a', 'b', 'c']);
-      });
-
-      afterEach(function(){
-        docs._processSubdirectories.restore();
-      });
-
-      it('should call _processSubdirectories for with the provided array', function() {
-        docs.get(opts, callback);
-        assert.ok(docs._processSubdirectories.calledWith(['a', 'b', 'c']));
-      });
-
-      it('should call async.each', function(){
-        sinon.stub(async, 'each');
-        docs.get(opts, callback);
-        assert.ok(async.each.calledOnce);
-        async.each.restore();
-      });
-    });
   });
 
   describe('_processDocument', function(){
@@ -109,95 +85,63 @@ describe('Unit - docs', function(){
     });
 
     it('should callback content if empty rules object', function(){
-      getDocStub.callsArgWith(2, null, {
+      getDocStub.callsArgWith(2, null, [{
         content: "My content!",
         rules: {}
-      });
+      }]);
       docs._processDocument('somedoc', '2015-01-01 00:00:00', {}, callback);
       assert.equal(callback.firstCall.args[1], 'My content!');
     });
 
+    it('Merges all the content that apply', function(){
+      getDocStub.callsArgWith(2, null, [{
+        content: "My content!",
+        rules: {}
+      }, {
+        content: 'My content2!',
+        rules: {}
+      }
+    ]);
+      docs._processDocument('somedoc', '2015-01-01 00:00:00', {}, callback);
+      assert.equal(callback.firstCall.args[1], 'My content!\nMy content2!');
+    });
+
     it('should callback content if empty rules object', function(){
-      getDocStub.callsArgWith(2, null, {
+      getDocStub.callsArgWith(2, null, [{
         content: "My content!",
         rules: {
           rule1: 'a',
           rule2: 'b'
         }
-      });
+      }]);
       docs._processDocument('somedoc', '2015-01-01 00:00:00', {}, callback);
       assert.ok(docs._runDocumentRules.calledOnce);
     });
 
     it('should callback content if _runDocumentRules returns true', function(){
-      getDocStub.callsArgWith(2, null, {
+      getDocStub.callsArgWith(2, null, [{
         content: "My content!",
         rules: {
           rule1: 'a',
           rule2: 'b'
         }
-      });
+      }]);
       docRulesStub.returns(true);
       docs._processDocument('somedoc', '2015-01-01 00:00:00', {}, callback);
       assert.equal(callback.firstCall.args[1], 'My content!');
     });
 
     it('should callback empty string if _runDocumentRules returns false', function(){
-      getDocStub.callsArgWith(2, null, {
+      getDocStub.callsArgWith(2, null, [{
         content: "My content!",
         rules: {
           rule1: 'a',
           rule2: 'b'
         }
-      });
+      }]);
       docRulesStub.returns(false);
       docs._processDocument('somedoc', '2015-01-01 00:00:00', {}, callback);
       assert.equal(callback.firstCall.args[1], '');
-    });
-  });
-
-  describe('_processSubdirectories', function() {
-    var callback = null;
-    var paragraphCheck = null;
-    var parentDirectories;
-
-    beforeEach(function() {
-      callback = sinon.spy();
-      paragraphCheck = sinon.stub(docs.connector, 'checkForParagraphs');
-      parentDirectories = ['a'];
-    });
-
-    afterEach(function(){
-      callback = null;
-      docs.connector.checkForParagraphs.restore();
-    });
-
-    context('when no parent directories are provided', function() {
-      it('should return an empty array', function(){
-        var documents = docs._processSubdirectories(null);
-        assert.deepEqual(documents, []);
-      });
-    });
-
-    context('when we have parent directories', function() {
-      it('should call async.each', function(){
-        sinon.stub(async, 'each');
-        docs._processSubdirectories(parentDirectories);
-        assert.ok(async.each.calledOnce);
-        async.each.restore();
-      });
-
-      it('should call connector.checkForParagraphs', function(){
-        docs._processSubdirectories(parentDirectories);
-        assert.ok(docs.connector.checkForParagraphs.calledOnce);
-      });
-
-      it('should return the just the sub directories for this parent if the database returns them', function(){
-        paragraphCheck.yields(null, [ { type: 'a/a_sub_document_one' }]);
-        var expected = [[ { type: 'a/a_sub_document_one' }]];
-        docs._processSubdirectories(parentDirectories, callback);
-        assert.deepEqual(callback.firstCall.args[1], expected);
-      });
     });
   });
 

--- a/tests/testNotEqual.js
+++ b/tests/testNotEqual.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+var notEqual = require('../lib/rules/notEqual.js');
+
+describe('notEqual', function() {
+  var arrayToCompare, value;
+  it('returns true if nothing is passed', function() {
+    assert.equal(notEqual(), true);
+  });
+
+  it('returns true if there is nothing to compare with', function() {
+    arrayToCompare = ['LG', 'LW', 'LN'];
+    assert.equal(notEqual(arrayToCompare), true);
+  });
+
+  it('returns false if there is a single match in the array', function() {
+    arrayToCompare = ['LG', 'LW', 'LN'];
+    value = 'LG';
+    assert.equal(notEqual(arrayToCompare, value), false);
+  });
+
+  it('returns true if there is no match array', function() {
+    arrayToCompare = ['LG', 'LW', 'LN'];
+    value = 'stuff';
+    assert.equal(notEqual(arrayToCompare, value), true);
+  });
+});


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
It changes the SQL query for doc-warrior to allow it to pull down multiple matching documents.

#### What tests does this PR have?
Updated unit tests.
`npm test`

#### How can this be tested?
1. On your local hapi delete to `node_modules/doc-warrior`
2. Clone this repo and inside the `node_modules` folder
3. Checkout this branch
3. Fire up hapi
4. Fire up render to pointing to your local hapi and check the following terms:
- [New Heathrow Product](http://localhost:8084/documents/terms/?agent=WT894&code=HPLHH2&booking_ref=HP4INDL&product=carparks&email=tobenna.ndu@holidayextras.com) - Should add the custom terms for Heathrow

- [New Product](http://localhost:8084/documents/terms/?agent=WT894&code=HPLGU2&booking_ref=HP4INDK&product=carparks&email=tobenna.ndu@holidayextras.com) - Should show terms and conditions including cancellation information

- [Old Product](http://localhost:8084/documents/terms/?booking_ref=HP42ISU&code=LHU4&agent=WEB1&product=carparks&email=chris.gale@holidayextras.com) - Should show an older version of terms and conditions from January

- [Generic Product](http://localhost:8084/documents/terms) - Should show terms excluding cancelation

#### What domains are affected?
All

#### Any tech debt?
N/A

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/l0IygSmXGylPVXyAE/giphy.gif)

##### Code Review
- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed (or I have clearly labeled this pull request "work in progress" or similar).

By approving this pull request you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.
- Thought about whether this PR needs additional reviewers and requested if necessary.